### PR TITLE
Add Bazel Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the bazel build files.
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "scraper",
+    srcs = [
+        "main/main.go",
+    ],
+    deps = [
+        "//trackable:show",
+    ],
+)
+
+# TODO: Have the final tracker server also here. This is currently not possible
+#       as it is in server/main, which already belongs to //server. Consider
+#       readjusting the project structure so it can be placed here.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,66 @@
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz",
+    sha256 = "c1f52b8789218bb1542ed362c4f7de7052abcf254d865d96fb7ba6d44bc15ee3",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains",)
+go_rules_dependencies()
+go_register_toolchains()
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()
+
+# External Dependencies
+
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+go_repository(
+    name = "com_github_gorilla_mux",
+    importpath = "github.com/gorilla/mux",
+    tag = "v1.6.1",
+)
+
+go_repository(
+    name = "com_github_gorilla_context",
+    importpath = "github.com/gorilla/context",
+    tag = "v1.1",
+)
+
+go_repository(
+    name = "com_github_gorilla_sessions",
+    importpath = "github.com/gorilla/sessions",
+    tag = "v1.1",
+)
+
+go_repository(
+    name = "com_github_gorilla_securecookie",
+    importpath = "github.com/gorilla/securecookie",
+    tag = "v1.1.1",
+)
+
+go_repository(
+    name = "org_golang_x_oauth2",
+    importpath = "golang.org/x/oauth2",
+    remote = "git@github.com:golang/oauth2",
+    vcs = "git",
+    commit = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269",
+)
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    remote = "git@github.com:golang/net",
+    vcs = "git",
+    commit = "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+)
+
+go_repository(
+    name = "com_google_cloud_go",
+    importpath = "cloud.google.com/go",
+    tag = "v0.22.0",
+)
+
+go_repository(
+    name = "com_github_go-sql-driver_mysql",
+    importpath = "github.com/go-sql-driver/mysql",
+    tag = "v1.3",
+)

--- a/bazel.md
+++ b/bazel.md
@@ -1,0 +1,45 @@
+Bazel Compilation Instructions
+==============================
+
+Building with bazel means you can place the directory anywhere in your system.
+It also double acts as dependency control system with versioning.
+
+---
+
+Building
+--------
+
+Instructions are pretty similar to the ones outlined in README.md
+
+1. Make sure you have [Bazel][1] installed
+2. Initialize the schema located in `schemas/schema.sql`
+3. Build and run the scraper:
+
+   ```shell
+   bazel run //:scraper
+   ```
+
+4. Build and run the server:
+
+   ```shell
+   bazel run //server
+   ```
+
+---
+
+Adding Dependencies
+-------------------
+
+Make sure to add any external dependencies in `WORKSPACE`. Don't forget to
+then add them to the appropate `BUILD` files where they are required.
+
+---
+
+Complaints
+----------
+
+Complain to [@Voytechnology][2] - If there are any questions regarding Bazel,
+add `@Voytechnology` in the comments.
+
+[1]: https://bazel.build
+[2]: https://github.com/voytechnology

--- a/database/BUILD.bazel
+++ b/database/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "database",
+    srcs = ["database.go"],
+    importpath = "tracker/database",
+)

--- a/scrape/BUILD.bazel
+++ b/scrape/BUILD.bazel
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "scrape",
+    srcs = ["scraper.go"],
+    deps = [
+        "@org_golang_x_net//html:go_default_library",
+    ],
+    importpath = "tracker/scrape",
+)
+
+go_test(
+    name = "scrape_test",
+    srcs = ["scraper_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":scrape"],
+)

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "auth",
+    srcs = [
+        "auth/auth.go",
+        "auth/user.go",
+    ],
+    deps = [
+        ":page",
+        "//database",
+        "//trackable:common",
+        "@com_github_gorilla_mux//:go_default_library",
+        "@com_github_gorilla_sessions//:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+    ],
+    importpath = "tracker/server/auth",
+)
+
+go_library(
+    name = "page",
+    srcs = ["page/page.go"],
+    importpath = "tracker/server/page",
+)
+
+go_library(
+    name = "server_lib",
+    srcs = ["server.go"],
+    deps = [
+        ":auth",
+        "//trackable:common",
+        "//trackable:show",
+        "//templates",
+    ],
+    importpath = "tracker/server",
+)
+
+go_binary(
+    name = "server",
+    srcs = ["main/main.go"],
+    deps = [
+        ":server_lib",
+        "//trackable:common",
+    ],
+)

--- a/templates/BUILD.bazel
+++ b/templates/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "templates",
+    srcs = ["functions.go"],
+    data = glob(["public/**", "shows/**"]),
+    importpath = "tracker/templates",
+)

--- a/trackable/BUILD.bazel
+++ b/trackable/BUILD.bazel
@@ -1,0 +1,51 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "common",
+    srcs = [
+        "common/date.go",
+        "common/host.go",
+        "common/util.go",
+    ],
+    importpath = "tracker/trackable/common",
+)
+
+go_test(
+    name = "common_test",
+    srcs = [
+        "common/date_test.go",
+    ],
+    embed = [":common"],
+)
+
+go_library(
+    name = "music",
+    srcs = [
+        "music/music.go",
+    ],
+    importpath = "tracker/trackable/music",
+)
+
+go_library(
+    name = "show",
+    srcs = [
+        "show/api.go",
+        "show/collector.go",
+        "show/frontend.go",
+        "show/handler.go",
+        "show/show.go",
+    ],
+    deps = [
+        ":common",
+        "//database",
+        "//server:page",
+        "//server:auth",
+        "//scrape",
+        "//templates",
+        "@com_github_gorilla_mux//:go_default_library",
+        "@com_github_go-sql-driver_mysql//:go_default_library",
+    ],
+    importpath = "tracker/trackable/show",
+)


### PR DESCRIPTION
Currently the project forces the user to keep the project in `$GOPATH/src/tracker`. Adding Bazel is one of the solutions.

This has several benefits, namely:
- Ability to place the project anywhere on the machine
- No need to maintain GOPATH
- Dependency version control

The main disadvantage is that the BUILD files have to be maintained.