### PR TITLE
Add Go Module support.

### DIFF
--- a/.gitattibutes
+++ b/.gitattibutes
@@ -1,0 +1,1 @@
+go.sum linguist-generated

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module tracker
+
+require (
+	cloud.google.com/go v0.27.0 // indirect
+	github.com/go-sql-driver/mysql v1.4.0
+	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/sessions v1.1.2
+	golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+cloud.google.com/go v0.27.0 h1:Xa8ZWro6QYKOwDKtxfKsiE0ea2jD39nx32RxtF5RjYE=
+cloud.google.com/go v0.27.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
+github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
+github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.1.2 h1:4esMHhwKLQ9Odtku/p+onvH+eRJFWjV4y3iTDVWrZNU=
+github.com/gorilla/sessions v1.1.2/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
+golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3 h1:czFLhve3vsQetD6JOJ8NZZvGQIXlnN3/yXxbT6/awxI=
+golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
This allows the project to be installed outside of the `$GOPATH` using just standard Go.

[Go Modules][1] support has been added in Go 1.11 as experimental opt-in feature. It should become enabled by default in Go 1.12, but for now has to be turned on by:

```sh
export GO111MODULE=on
```

sourced in `.profile` or appended before the command itself.

There should be no changes in how the thing operates, `go get` and other commands should work just fine. If you don't care about locking dependency versions, you can just remove the `require` block in `go.mod` and `go get ./...` to get the latest version of everything.

#14 was a flop because of extra dependency on bazel, but please @RyanConnell, this is pure Go.

[1]: https://github.com/golang/go/wiki/Modules