### PR TITLE
Use go1.16 for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
We are using the embed package which is part of Go 1.16. We were on the
older version in the CI.