### PR TITLE
Docker Support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [develop]
+    tags: [v*]
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+  DOCKER_IMAGE_PREFIX: ghcr.io/ryanconnell/tracker
+  DOCKER_PLATFORM: linux/amd64,linux/arm64
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # Setup
+    - uses: actions/checkout@v3
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/login-action@v2
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    # Create tags for different components
+    - uses: crazy-max/ghaction-docker-meta@v1
+      id: docker_meta_frontend
+      with:
+        images: ${{ env.DOCKER_IMAGE_PREFIX}}-frontend
+        tag-sha: true
+    
+    - uses: crazy-max/ghaction-docker-meta@v1
+      id: docker_meta_backend
+      with:
+        images: ${{ env.DOCKER_IMAGE_PREFIX}}-backend
+        tag-sha: true
+
+    - uses: docker/build-push-action@v2
+      with:
+        file: cmd/frontend/Dockerfile
+        platforms: ${{ env.DOCKER_PLATFORM }}
+        push: true
+        tags: ${{ steps.docker_meta_frontend.outputs.tags }}
+        labels: ${{ steps.docker_meta_frontend.outputs.labels }}
+
+    - name: Build and Push Backend
+      uses: docker/build-push-action@v2
+      with:
+        file: cmd/frontend/Dockerfile
+        platforms: ${{ env.DOCKER_PLATFORM }}
+        push: true
+        tags: ${{ steps.docker_meta_backend.outputs.tags }}
+        labels: ${{ steps.docker_meta_backend.outputs.labels }}

--- a/cmd/backend/Dockerfile
+++ b/cmd/backend/Dockerfile
@@ -1,0 +1,32 @@
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+
+RUN mkdir /user && \
+    echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
+    echo 'nobody:x:65534:' > /user/group
+
+WORKDIR /src
+
+ENV CGO_ENABLED=0
+
+RUN apk --update add ca-certificates git
+
+COPY . .
+
+RUN go mod download
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags '-s -w' -o /bin/tracker-backend ./cmd/backend
+
+################################################################################
+
+FROM scratch AS final
+
+USER nobody:nobody
+
+COPY --from=builder /user/group /user/passwd /etc/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /bin/tracker-backend /usr/local/bin/tracker-backend
+
+ENTRYPOINT ["/usr/local/bin/tracker-backend"]

--- a/cmd/frontend/Dockerfile
+++ b/cmd/frontend/Dockerfile
@@ -1,0 +1,32 @@
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+
+RUN mkdir /user && \
+    echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
+    echo 'nobody:x:65534:' > /user/group
+
+WORKDIR /src
+
+ENV CGO_ENABLED=0
+
+RUN apk --update add ca-certificates git
+
+COPY . .
+
+RUN go mod download
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags '-s -w' -o /bin/tracker-frontend ./cmd/frontend
+
+################################################################################
+
+FROM scratch AS final
+
+USER nobody:nobody
+
+COPY --from=builder /user/group /user/passwd /etc/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /bin/tracker-frontend /usr/local/bin/tracker-frontend
+
+ENTRYPOINT ["/usr/local/bin/tracker-frontend"]


### PR DESCRIPTION
This change adds support for multiplatform Docker builds. On a push to
the develop branch or a tag, a new Docker image would be created.

There is one additional thing you have to do @RyanConnell to make it work

1. Enable Improved Container Support: https://docs.github.com/en/packages/guides/enabling-improved-container-support
2. Go to  https://github.com/settings/tokens
3. Create New Token with `repo`, `write:packages` permissions
4. Copy the generated token
5. Go to https://github.com/RyanConnell/tracker/settings/secrets/actions/new
6. Create a new secret with the name `DOCKER_REGISTRY_TOKEN` and value is the copied generated token
    